### PR TITLE
added iOS home screen icon

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -16,7 +16,12 @@
       sizes="196x196"
       href="{{rootURL}}assets/images/sharedrop-icon.png"
     />
-
+    <link
+    rel="apple-touch-icon"
+    sizes="196x196"
+    href="{{rootURL}}assets/images/sharedrop-icon.png"
+    />
+    
     {{content-for "head"}}
 
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css" />


### PR DESCRIPTION
Trying to add this site to home screen on iOS (iPhone or iPad) doesn't use the favicon. This one-liner should fix it. 

![image](https://user-images.githubusercontent.com/25871041/217120484-7d613079-5080-4a6c-afd2-5fdb365d78d0.png)

Apple documentation: https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html
