### PR TITLE
Add `target="_blank"` to Ukraine anchor link

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -32,4 +32,4 @@
   </div>
 </footer>
 
-<a href="https://war.ukraine.ua/" class="ribbon"><span class="visually-hidden">We stand with Ukraine!</span></a>
+<a href="https://war.ukraine.ua/" class="ribbon" target="_blank"><span class="visually-hidden">We stand with Ukraine!</span></a>


### PR DESCRIPTION
Makes the Ukraine banner open the link in a new window.
Had me recently. Clicked the Ukraine banner, ShareDrop interrupts the file transfer.